### PR TITLE
Add custom handler for tag suggestions

### DIFF
--- a/doc/comic_source.md
+++ b/doc/comic_source.md
@@ -331,6 +331,16 @@ This part is used to load comics of a category.
 
         // enable tags suggestions
         enableTagsSuggestions: false,
+
+        /**
+         * [Optional] handle tag suggestion click
+         * @param namespace {string}
+         * @param value {string}
+         * @returns {string} - text added to search bar
+         */
+        onTagSuggestionSelected: (namespace, value) => {
+            return `${namespace}:${value}`
+        },
     }
 ```
 

--- a/lib/foundation/comic_source/comic_source.dart
+++ b/lib/foundation/comic_source/comic_source.dart
@@ -186,6 +186,8 @@ class ComicSource {
 
   final LinkHandler? linkHandler;
 
+  final TagSuggestionSelectedFunc? onTagSuggestionSelected;
+
   final bool enableTagsSuggestions;
 
   final bool enableTagsTranslate;
@@ -260,6 +262,7 @@ class ComicSource {
     this.translations,
     this.handleClickTagEvent,
     this.linkHandler,
+    this.onTagSuggestionSelected,
     this.enableTagsSuggestions,
     this.enableTagsTranslate,
     this.starRatingFunc,
@@ -377,7 +380,10 @@ class SearchPageData {
 
   final SearchNextFunction? loadNext;
 
-  const SearchPageData(this.searchOptions, this.loadPage, this.loadNext);
+  final TagSuggestionSelectedFunc? onTagSuggestionSelected;
+
+  const SearchPageData(this.searchOptions, this.loadPage, this.loadNext,
+      this.onTagSuggestionSelected);
 }
 
 class SearchOptions {

--- a/lib/foundation/comic_source/parser.dart
+++ b/lib/foundation/comic_source/parser.dart
@@ -614,6 +614,7 @@ class ComicSourceParser {
     SearchFunction? loadPage;
 
     SearchNextFunction? loadNext;
+    TagSuggestionSelectedFunc? onTagSuggestionSelected;
 
     if (_checkExists('search.load')) {
       loadPage = (keyword, page, searchOption) async {
@@ -649,8 +650,9 @@ class ComicSourceParser {
         }
       };
     }
+    onTagSuggestionSelected = _parseTagSuggestionSelected();
 
-    return SearchPageData(options, loadPage, loadNext);
+    return SearchPageData(options, loadPage, loadNext, onTagSuggestionSelected);
   }
 
   LoadComicFunc? _parseLoadComicFunc() {
@@ -1070,6 +1072,18 @@ class ComicSourceParser {
     }
 
     return LinkHandler(domains, linkToId);
+  }
+
+  TagSuggestionSelectedFunc? _parseTagSuggestionSelected() {
+    if (!_checkExists('search.onTagSuggestionSelected')) {
+      return null;
+    }
+    return (namespace, value) {
+      var res = JsEngine().runCode(
+        "ComicSource.sources.\$_key.search.onTagSuggestionSelected(${jsonEncode(namespace)}, ${jsonEncode(value)})",
+      );
+      return res?.toString();
+    };
   }
 
   StarRatingFunc? _parseStarRatingFunc() {

--- a/lib/foundation/comic_source/types.dart
+++ b/lib/foundation/comic_source/types.dart
@@ -44,5 +44,8 @@ typedef VoteCommentFunc = Future<Res<int?>> Function(
 typedef HandleClickTagEvent = PageJumpTarget? Function(
     String namespace, String tag);
 
+typedef TagSuggestionSelectedFunc = String? Function(
+    String namespace, String value);
+
 /// [rating] is the rating value, 0-10. 1 represents 0.5 star.
 typedef StarRatingFunc = Future<Res<bool>> Function(String comicId, int rating);

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -376,11 +376,20 @@ class _SearchPageState extends State<SearchPage> {
         controller.text =
             controller.text.replaceLast(words[words.length - 1], "");
       }
-      if (type != null) {
-        controller.text += "${type.name}:$text ";
-      } else {
-        controller.text += "$text ";
+      String? insert = ComicSource
+          .find(searchTarget)!
+          .searchPageData
+          ?.onTagSuggestionSelected
+          ?.call(type?.name ?? '', text);
+      if (insert == null) {
+        var v = text;
+        if (type != null) {
+          insert = "${type.name}:$v";
+        } else {
+          insert = v;
+        }
       }
+      controller.text += "$insert ";
       suggestions.clear();
       update();
       focusNode.requestFocus();

--- a/lib/pages/search_result_page.dart
+++ b/lib/pages/search_result_page.dart
@@ -400,14 +400,23 @@ class _SuggestionsState extends State<_Suggestions> {
       controller.text =
           controller.text.replaceLast(words[words.length - 1], "");
     }
-    if (text.contains(' ')) {
-      text = "'$text'";
+    String? insert = ComicSource
+        .find(widget.sourceKey)!
+        .searchPageData
+        ?.onTagSuggestionSelected
+        ?.call(type?.name ?? '', text);
+    if (insert == null) {
+      var v = text;
+      if (v.contains(' ')) {
+        v = "'$v'";
+      }
+      if (type != null) {
+        insert = "${type.name}:$v";
+      } else {
+        insert = v;
+      }
     }
-    if (type != null) {
-      controller.text += "${type.name}:$text ";
-    } else {
-      controller.text += "$text ";
-    }
+    controller.text += "$insert ";
     widget.controller.suggestions.clear();
     widget.controller.remove();
   }


### PR DESCRIPTION
## Summary
- introduce `TagSuggestionSelectedFunc` and related parser
- allow comic sources to override tag suggestion handling
- document `search.onTagSuggestionSelected`

## Testing
- `dart format -o none --set-exit-if-changed lib doc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840eb5a61208325a62a658e2ceb14df