### PR TITLE
Add hook for custom tag suggestion text

### DIFF
--- a/lib/foundation/comic_source/comic_source.dart
+++ b/lib/foundation/comic_source/comic_source.dart
@@ -376,8 +376,10 @@ class SearchPageData {
   final SearchFunction? loadPage;
 
   final SearchNextFunction? loadNext;
+  final TagSuggestionSelectedFunc? onTagSuggestionSelected;
 
-  const SearchPageData(this.searchOptions, this.loadPage, this.loadNext);
+  const SearchPageData(
+      this.searchOptions, this.loadPage, this.loadNext, this.onTagSuggestionSelected);
 }
 
 class SearchOptions {

--- a/lib/foundation/comic_source/parser.dart
+++ b/lib/foundation/comic_source/parser.dart
@@ -650,7 +650,21 @@ class ComicSourceParser {
       };
     }
 
-    return SearchPageData(options, loadPage, loadNext);
+    TagSuggestionSelectedFunc? onTagSuggestionSelected;
+    if (_checkExists("search.onTagSuggestionSelected")) {
+      onTagSuggestionSelected = (namespace, tag) async {
+        var res = JsEngine().runCode("""
+          ComicSource.sources.$_key.search.onTagSuggestionSelected(
+            ${jsonEncode(namespace)}, ${jsonEncode(tag)})
+        """);
+        if (res is Future) {
+          res = await res;
+        }
+        return res.toString();
+      };
+    }
+
+    return SearchPageData(options, loadPage, loadNext, onTagSuggestionSelected);
   }
 
   LoadComicFunc? _parseLoadComicFunc() {

--- a/lib/foundation/comic_source/types.dart
+++ b/lib/foundation/comic_source/types.dart
@@ -46,3 +46,6 @@ typedef HandleClickTagEvent = PageJumpTarget? Function(
 
 /// [rating] is the rating value, 0-10. 1 represents 0.5 star.
 typedef StarRatingFunc = Future<Res<bool>> Function(String comicId, int rating);
+
+typedef TagSuggestionSelectedFunc = Future<String> Function(
+    String namespace, String tag)?;

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -365,7 +365,7 @@ class _SearchPageState extends State<SearchPage> {
       return false;
     }
 
-    void onSelected(String text, TranslationType? type) {
+    Future<void> onSelected(String text, TranslationType? type) async {
       var words = controller.text.split(" ");
       if (words.length >= 2 &&
           check("${words[words.length - 2]} ${words[words.length - 1]}", text,
@@ -377,7 +377,16 @@ class _SearchPageState extends State<SearchPage> {
             controller.text.replaceLast(words[words.length - 1], "");
       }
       if (type != null) {
-        controller.text += "${type.name}:$text ";
+        var func = ComicSource.find(searchTarget)!
+            .searchPageData?.onTagSuggestionSelected;
+        if (func != null) {
+          try {
+            text = await func(type.name, text);
+          } catch (_) {}
+          controller.text += "$text ";
+        } else {
+          controller.text += "${type.name}:$text ";
+        }
       } else {
         controller.text += "$text ";
       }

--- a/lib/pages/search_result_page.dart
+++ b/lib/pages/search_result_page.dart
@@ -388,7 +388,7 @@ class _SuggestionsState extends State<_Suggestions> {
     return false;
   }
 
-  void onSelected(String text, TranslationType? type) {
+  Future<void> onSelected(String text, TranslationType? type) async {
     var controller = widget.controller.controller;
     var words = controller.text.split(" ");
     if (words.length >= 2 &&
@@ -404,7 +404,16 @@ class _SuggestionsState extends State<_Suggestions> {
       text = "'$text'";
     }
     if (type != null) {
-      controller.text += "${type.name}:$text ";
+      var func = ComicSource.find(sourceKey)!
+          .searchPageData?.onTagSuggestionSelected;
+      if (func != null) {
+        try {
+          text = await func(type.name, text);
+        } catch (_) {}
+        controller.text += "$text ";
+      } else {
+        controller.text += "${type.name}:$text ";
+      }
     } else {
       controller.text += "$text ";
     }


### PR DESCRIPTION
## Summary
- extend `SearchPageData` with `onTagSuggestionSelected` callback
- support parsing `search.onTagSuggestionSelected` from JS sources
- allow pages to call the new callback when tag suggestions are chosen
- add new `TagSuggestionSelectedFunc` typedef

## Testing
- `dart` and `flutter` were unavailable so formatting and analysis couldn't run

------
https://chatgpt.com/codex/tasks/task_e_684bd78353188325b02d782f82638127