### PR TITLE
Add tag suggestion callback

### DIFF
--- a/doc/comic_source.md
+++ b/doc/comic_source.md
@@ -363,6 +363,11 @@ This part is used to load comics of a category.
 
         // enable tags suggestions
         enableTagsSuggestions: false,
+        // [Optional] handle tag suggestion click
+        onTagSuggestionSelected: (namespace, tag) => {
+            // return the text to insert into search box
+            return `${namespace}:${tag}`
+        },
     }
 ```
 

--- a/lib/foundation/comic_source/comic_source.dart
+++ b/lib/foundation/comic_source/comic_source.dart
@@ -184,6 +184,9 @@ class ComicSource {
 
   final HandleClickTagEvent? handleClickTagEvent;
 
+  /// Callback when a tag suggestion is selected in search.
+  final TagSuggestionSelectFunc? onTagSuggestionSelected;
+
   final LinkHandler? linkHandler;
 
   final bool enableTagsSuggestions;
@@ -259,6 +262,7 @@ class ComicSource {
     this.idMatcher,
     this.translations,
     this.handleClickTagEvent,
+    this.onTagSuggestionSelected,
     this.linkHandler,
     this.enableTagsSuggestions,
     this.enableTagsTranslate,

--- a/lib/foundation/comic_source/parser.dart
+++ b/lib/foundation/comic_source/parser.dart
@@ -148,6 +148,7 @@ class ComicSourceParser {
       _parseIdMatch(),
       _parseTranslation(),
       _parseClickTagEvent(),
+      _parseTagSuggestionSelectFunc(),
       _parseLinkHandler(),
       _getValue("search.enableTagsSuggestions") ?? false,
       _getValue("comic.enableTagsTranslate") ?? false,
@@ -1054,6 +1055,19 @@ class ComicSourceParser {
       var r = Map<String, dynamic>.from(res);
       r.removeWhere((key, value) => value == null);
       return PageJumpTarget.parse(_key!, r);
+    };
+  }
+
+  TagSuggestionSelectFunc? _parseTagSuggestionSelectFunc() {
+    if (!_checkExists("search.onTagSuggestionSelected")) {
+      return null;
+    }
+    return (namespace, tag) {
+      var res = JsEngine().runCode("""
+          ComicSource.sources.$_key.search.onTagSuggestionSelected(
+            ${jsonEncode(namespace)}, ${jsonEncode(tag)})
+        """);
+      return res is String ? res : "$namespace:$tag";
     };
   }
 

--- a/lib/foundation/comic_source/types.dart
+++ b/lib/foundation/comic_source/types.dart
@@ -44,5 +44,10 @@ typedef VoteCommentFunc = Future<Res<int?>> Function(
 typedef HandleClickTagEvent = PageJumpTarget? Function(
     String namespace, String tag);
 
+/// Handle tag suggestion selection event. Should return the text to insert
+/// into the search field.
+typedef TagSuggestionSelectFunc = String Function(
+    String namespace, String tag);
+
 /// [rating] is the rating value, 0-10. 1 represents 0.5 star.
 typedef StarRatingFunc = Future<Res<bool>> Function(String comicId, int rating);

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -376,11 +376,16 @@ class _SearchPageState extends State<SearchPage> {
         controller.text =
             controller.text.replaceLast(words[words.length - 1], "");
       }
-      if (type != null) {
-        controller.text += "${type.name}:$text ";
+      final source = ComicSource.find(searchTarget);
+      String insert;
+      if (source?.onTagSuggestionSelected != null) {
+        insert = source!.onTagSuggestionSelected!(type?.name ?? '', text);
       } else {
-        controller.text += "$text ";
+        var t = text;
+        if (t.contains(' ')) t = "'$t'";
+        insert = type != null ? "${type.name}:$t" : t;
       }
+      controller.text += "$insert ";
       suggestions.clear();
       update();
       focusNode.requestFocus();

--- a/lib/pages/search_result_page.dart
+++ b/lib/pages/search_result_page.dart
@@ -124,7 +124,7 @@ class _SearchResultPageState extends State<SearchResultPage> {
     options = widget.options ?? const [];
     validateOptions();
     appdata.addSearchHistory(text);
-    suggestionsController = _SuggestionsController(controller);
+    suggestionsController = _SuggestionsController(controller, sourceKey);
     super.initState();
   }
 
@@ -213,6 +213,8 @@ class _SuggestionsController {
 
   final SearchBarController controller;
 
+  final String sourceKey;
+
   OverlayEntry? entry;
 
   void updateWidget() {
@@ -270,7 +272,7 @@ class _SuggestionsController {
     find(TagsTranslation.cosplayerTags, TranslationType.cosplayer);
   }
 
-  _SuggestionsController(this.controller);
+  _SuggestionsController(this.controller, this.sourceKey);
 }
 
 class _Suggestions extends StatefulWidget {
@@ -400,14 +402,16 @@ class _SuggestionsState extends State<_Suggestions> {
       controller.text =
           controller.text.replaceLast(words[words.length - 1], "");
     }
-    if (text.contains(' ')) {
-      text = "'$text'";
-    }
-    if (type != null) {
-      controller.text += "${type.name}:$text ";
+    final source = ComicSource.find(widget.controller.sourceKey);
+    String insert;
+    if (source?.onTagSuggestionSelected != null) {
+      insert = source!.onTagSuggestionSelected!(type?.name ?? '', text);
     } else {
-      controller.text += "$text ";
+      var t = text;
+      if (t.contains(' ')) t = "'$t'";
+      insert = type != null ? "${type.name}:$t" : t;
     }
+    controller.text += "$insert ";
     widget.controller.suggestions.clear();
     widget.controller.remove();
   }


### PR DESCRIPTION
## Summary
- allow config to define a `search.onTagSuggestionSelected` handler
- support using the callback when selecting suggested tags in search pages
- document the new callback in comic source docs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f5731b108325acee0561d46baf77